### PR TITLE
rmarkdown as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ r_packages:
   - mboost
   - gamboostLSS
   - QUIC
+  - rmarkdown
   
 after_failure:
   - ./travis-tool.sh dump_logs


### PR DESCRIPTION
I think the travis error may be due to the lack of rmarkdown. For some reason knitr doesn't pull it in.

I'm sending the pull request to test this idea.