### PR TITLE
Fix error True/False is expected but vector is received in assertion

### DIFF
--- a/R/stabsel.R
+++ b/R/stabsel.R
@@ -312,7 +312,7 @@ run_stabsel <- function(fitter, args.fitter,
         res[idx] <- NULL
     }
     ## check results
-    if (!is.list(res[[1]]) && names(res[[1]]) != c("selected", "path"))
+    if (!is.list(res[[1]]) || !all(c("selected", "path") %in% names(res[[1]])))
         stop(sQuote("fitfun"), " must return a list with two (named) elements",
              ", i.e., ", sQuote("selected"), " and ", sQuote("path"))
 


### PR DESCRIPTION
The previous code was always triggering an exception (R 3.3.1) when evaluating the if() statement because a vector was used on the right hand side of a logical && predicate. Additionally, the logical predicate itself was incorrect according to the meaning of the error message in the stop() call.
Also, the modified expression is now more generic because it allows for the presence of other names in the res list in addition to the two names that are required to be present.