### PR TITLE
Make fitfuns more quiet

### DIFF
--- a/R/fitfuns.R
+++ b/R/fitfuns.R
@@ -7,7 +7,7 @@
 ################################################################################
 
 glmnet.lasso <- function(x, y, q, ...) {
-    if (!requireNamespace("glmnet"))
+    if (!requireNamespace("glmnet", quietly=TRUE))
         stop("Package ", sQuote("glmnet"), " needed but not available")
 
     if (is.data.frame(x)) {
@@ -33,7 +33,7 @@ glmnet.lasso <- function(x, y, q, ...) {
 }
 
 lars.lasso <- function(x, y, q, ...) {
-    if (!requireNamespace("lars"))
+    if (!requireNamespace("lars", quietly=TRUE))
         stop("Package ", sQuote("lars"), " needed but not available")
 
     if (is.data.frame(x)) {
@@ -66,7 +66,7 @@ lars.lasso <- function(x, y, q, ...) {
 }
 
 lars.stepwise <- function(x, y, q, ...) {
-    if (!requireNamespace("lars"))
+    if (!requireNamespace("lars", quietly=TRUE))
         stop("Package ", sQuote("lars"), " needed but not available")
 
     if (is.data.frame(x)) {
@@ -99,7 +99,7 @@ lars.stepwise <- function(x, y, q, ...) {
 }
 
 glmnet.lasso_maxCoef <- function(x, y, q, ...) {
-    if (!requireNamespace("glmnet"))
+    if (!requireNamespace("glmnet", quietly=TRUE))
         stop("Package ", sQuote("glmnet"), " needed but not available")
 
     if (is.data.frame(x)) {


### PR DESCRIPTION
Added `quietly=TRUE` option to `requireNamespace` calls in `fitfuns.R`, otherwise it looks like this:

![image](https://cloud.githubusercontent.com/assets/1140359/20661617/0de22930-b550-11e6-9e9f-3905246484e9.png)
