### PR TITLE
Keep variable selection results of subsamples and visualize

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -133,7 +133,7 @@ plot.stabsel <- function(x, main = deparse(x$call),
       heat <- heat[apply(heat, 1, sd) > .Machine$double.eps, ]
       heat <- heat[, apply(heat, 2, sd) > .Machine$double.eps]
       pheatmap::pheatmap(heat, color = c('white', 'lightblue'),
-                         cluster_rows = FALSE, show_rownames = FALSE)
+                         treeheight_row = 0, show_rownames = FALSE)
     } else {
         ## if par(mar) not set by user ahead of plotting
         if (all(par()[["mar"]] == c(5, 4, 4, 2) + 0.1))

--- a/R/methods.R
+++ b/R/methods.R
@@ -78,7 +78,8 @@ print.stabsel_parameters <- function(x, heading = TRUE, ...) {
     invisible(x)
 }
 
-plot.stabsel <- function(x, main = deparse(x$call), type = c("maxsel", "paths"),
+plot.stabsel <- function(x, main = deparse(x$call),
+                         type = c("maxsel", "paths", "subsamples"),
                          xlab = NULL, ylab = NULL,
                          col = NULL, ymargin = 10, np = sum(x$max > 0),
                          labels = NULL, ...) {
@@ -90,6 +91,11 @@ plot.stabsel <- function(x, main = deparse(x$call), type = c("maxsel", "paths"),
     if (type == "paths" && is.null(x$phat)) {
         warning("Stability paths ", sQuote("x$phat"), " are missing, ",
                 "plot maximum selection frequency instead")
+        type <- "maxsel"
+    }
+    if (type == "subsamples" && is.null(x$selection.per.subsample)) {
+        warning("Subsample selections ", sQuote("x$selection.per.subsample"), " are missing, ",
+                "use keep.subsampling=T in stansel call. Plotting maximum selection frequency instead")
         type <- "maxsel"
     }
     if (type == "paths") {
@@ -117,6 +123,17 @@ plot.stabsel <- function(x, main = deparse(x$call), type = c("maxsel", "paths"),
             labels <- rownames(x$phat)
         axis(4, at = x$phat[rowSums(x$phat) > 0, ncol(x$phat)],
              labels = labels[rowSums(x$phat) > 0], las = 1, ...)
+    } else if (type == "subsamples") {
+      if (!requireNamespace("pheatmap", quietly=TRUE)) {
+        stop("Package ", sQuote("pheatmap"), " needed but not available")
+      }
+      heat <- x$selection.per.subsample
+      mode(heat) <- 'numeric'
+      #exclude rows and cols with zero sd
+      heat <- heat[apply(heat, 1, sd) > .Machine$double.eps, ]
+      heat <- heat[, apply(heat, 2, sd) > .Machine$double.eps]
+      pheatmap::pheatmap(heat, color = c('white', 'lightblue'),
+                         cluster_rows = FALSE, show_rownames = FALSE)
     } else {
         ## if par(mar) not set by user ahead of plotting
         if (all(par()[["mar"]] == c(5, 4, 4, 2) + 0.1))

--- a/R/methods.R
+++ b/R/methods.R
@@ -95,7 +95,7 @@ plot.stabsel <- function(x, main = deparse(x$call),
     }
     if (type == "subsamples" && is.null(x$selection.per.subsample)) {
         warning("Subsample selections ", sQuote("x$selection.per.subsample"), " are missing, ",
-                "use keep.subsampling=T in stansel call. Plotting maximum selection frequency instead")
+                "use keep.subsampling=T in stabsel call. Plotting maximum selection frequency instead")
         type <- "maxsel"
     }
     if (type == "paths") {

--- a/R/stabsel.R
+++ b/R/stabsel.R
@@ -15,6 +15,7 @@ stabsel.matrix <- function(x, y, fitfun = lars.lasso, args.fitfun = list(),
                            assumption = c("unimodal", "r-concave", "none"),
                            sampling.type = c("SS", "MB"),
                            papply = mclapply, mc.preschedule = FALSE,
+                           keep.subsampling = FALSE,
                            verbose = TRUE, FWER, eval = TRUE,
                            ...) {
     cll <- match.call()
@@ -82,7 +83,8 @@ stabsel.matrix <- function(x, y, fitfun = lars.lasso, args.fitfun = list(),
                 PFER = PFER, folds = folds, B = B, assumption = assumption,
                 sampling.type = sampling.type, papply = papply,
                 verbose = verbose, FWER = FWER, eval = eval, names = nms,
-                mc.preschedule = mc.preschedule, ...)
+                mc.preschedule = mc.preschedule,
+                keep.subsampling = keep.subsampling,...)
     ret$call <- cll
     ret$call[[1]] <- as.name("stabsel")
     return(ret)
@@ -273,7 +275,7 @@ stabsel_parameters.default <- function(p, cutoff, q, PFER,
 run_stabsel <- function(fitter, args.fitter,
                         n, p, cutoff, q, PFER, folds, B, assumption,
                         sampling.type, papply, verbose, FWER, eval, names,
-                        mc.preschedule = FALSE, ...) {
+                        mc.preschedule = FALSE, keep.subsampling = FALSE, ...) {
 
     folds <- check_folds(folds, B = B, n = n, sampling.type = sampling.type)
     pars <- stabsel_parameters(p = p, cutoff = cutoff, q = q,
@@ -353,7 +355,11 @@ run_stabsel <- function(fitter, args.fitter,
     ret <- list(phat = phat,
                 selected = which(colMeans(res) >= cutoff),
                 max = colMeans(res),
-                subsample.selected=res)
+
+    if (keep.subsampling) {
+      ret$subsample.selected=res
+    }
+
     ret <- c(ret, pars)
 
     ## return violations as attribute

--- a/R/stabsel.R
+++ b/R/stabsel.R
@@ -357,7 +357,7 @@ run_stabsel <- function(fitter, args.fitter,
                 max = colMeans(res),
 
     if (keep.subsampling) {
-      ret$subsample.selected=res
+      ret$selected.per.subsample=res
     }
 
     ret <- c(ret, pars)

--- a/R/stabsel.R
+++ b/R/stabsel.R
@@ -352,7 +352,8 @@ run_stabsel <- function(fitter, args.fitter,
     
     ret <- list(phat = phat,
                 selected = which(colMeans(res) >= cutoff),
-                max = colMeans(res))
+                max = colMeans(res),
+                subsample.selected=res)
     ret <- c(ret, pars)
 
     ## return violations as attribute

--- a/R/stabsel.R
+++ b/R/stabsel.R
@@ -354,10 +354,10 @@ run_stabsel <- function(fitter, args.fitter,
     
     ret <- list(phat = phat,
                 selected = which(colMeans(res) >= cutoff),
-                max = colMeans(res),
+                max = colMeans(res))
 
     if (keep.subsampling) {
-      ret$selected.per.subsample=res
+      ret$selection.per.subsample=res
     }
 
     ret <- c(ret, pars)


### PR DESCRIPTION
I added a new option, `keep.subsampling = FALSE` to `stabsel` function to keep binary subsample variable selection matrix, so that users can visualize subsampling results. For that, I added a third option to plot function, `type="subsamples"` which uses `pheatmap` package to plot a heatmap. Code looks like this:

```R
> stab.lasso <- stabsel(x = bodyfat[, -2], y = bodyfat[,2],
                         fitfun = lars.lasso, cutoff = 0.75,
                         PFER = 1, keep.subsampling=T)
> plot(stab.lasso, type='subsamples')
```

and output is as follows:

![image](https://cloud.githubusercontent.com/assets/1140359/20676911/ba1e1538-b591-11e6-8ad0-57afafc954de.png)



Does it make sense to provide a way of visualizing subsample selection results like this?
